### PR TITLE
image: add f41 beta and version bump to 0.0.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ run2.bat
 logs/
 output/
 packer_cache/
+image_cache/
 
 # Eclipse Files
 .project

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PACKER_LOG := 1
 PACKER_LOG_PATH := ./logs/generic-parallels-log-$(shell date +'%Y%m%d.%H.%M.%S').log
 
 ifndef VERSION
-	VERSION := 0.0.8
+	VERSION := 0.0.9
 endif
 
 export PACKER_ON_ERROR

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ You can access all available versions on [https://app.vagrantup.com/dcagatay](ht
 
 ## Vagrant Boxes
 
+- [Fedora 41b](https://app.vagrantup.com/dcagatay/boxes/fedora-41b-aarch64)
 - [Fedora 40](https://app.vagrantup.com/dcagatay/boxes/fedora-40-aarch64)
 - [Fedora 39](https://app.vagrantup.com/dcagatay/boxes/fedora-39-aarch64)
 - ~~[Fedora 38](https://app.vagrantup.com/dcagatay/boxes/fedora-38-aarch64)~~
@@ -34,6 +35,10 @@ vagrant ssh
 
 ## Changelog
 
+- `0.0.9` _2024-10-23_
+  - Add Fedora 41 BETA box with kernel `6.11.5` and Parallels Tools `20.1.55732`.
+  - Update Fedora 40 box (`0.0.9`) with kernel `6.11.4` and Parallels Tools `20.1.55732`.
+  - Update Fedora 39 box (`0.0.9`) with kernel `6.11.4` and Parallels Tools `20.1.55732`.
 - `0.0.8` _2024-05-21_
   - Remove optional packages _vim_ and _wget_ from the installed packages.
   - Add Fedora 38 to the EOL list.
@@ -76,7 +81,7 @@ vagrant ssh
 
 The prerequisites to build the Vagrant box.
 
-- Packer (`brew install packer`)
+- Packer (`brew tap hashicorp/tap && brew install hashicorp/tap/packer`)
 - Parallels Desktop (`brew install --cask parallels`)
 - Parallels Virtualization SDK (`brew install --cask parallels-virtualization-sdk`)
 - Vagrant (`brew install --cask vagrant`) _For testing_
@@ -96,8 +101,9 @@ make box=<box-type> build-box
 
 `<box-type` can be one of the following:
 
+- `fedora41` ([Release schedule](https://fedorapeople.org/groups/schedule/f-41/f-41-key-tasks.html))
 - `fedora40` ([Release schedule](https://fedorapeople.org/groups/schedule/f-40/f-40-key-tasks.html))
-- `fedora39` ([Release schedule](https://fedorapeople.org/groups/schedule/f-39/f-39-key-tasks.html))
+- `fedora39` ([_EOL on 2023-11-12_](https://fedorapeople.org/groups/schedule/f-39/f-39-key-tasks.html))
 - `fedora38` ([_EOL on 2023-05-21_](https://fedorapeople.org/groups/schedule/f-38/f-38-key-tasks.html))
 - `fedora37` ([_EOL on 2022-12-13_](https://fedorapeople.org/groups/schedule/f-37/f-37-key-tasks.html))
 - `fedora36` (_EOL_)

--- a/http/generic.fedora41b.vagrant.ks
+++ b/http/generic.fedora41b.vagrant.ks
@@ -1,0 +1,46 @@
+text
+reboot --eject
+lang en_US.UTF-8
+keyboard us
+timezone US/Pacific
+rootpw --plaintext vagrant
+user --name=vagrant --password=vagrant --plaintext
+
+zerombr
+clearpart --all --initlabel
+autopart --noswap --type=btrfs
+
+firewall --enabled --service=ssh
+network --device eth0 --bootproto dhcp --noipv6 --hostname=fedora40.localdomain
+bootloader --timeout=1 --append="net.ifnames=0 biosdevname=0 no_timer_check vga=792 nomodeset text"
+
+# When this release is no longer available from mirrors, enable the archive url.
+# url --url=https://dl.fedoraproject.org/pub/archive/fedora/linux/releases/40/Everything/aarch64/os/
+
+%packages
+net-tools
+@core
+-mcelog
+-usbutils
+-microcode_ctl
+-smartmontools
+-plymouth
+-plymouth-core-libs
+-plymouth-scripts
+%end
+
+%post
+
+# Create the vagrant user account.
+/usr/sbin/useradd vagrant
+echo "vagrant" | passwd --stdin vagrant
+
+# Make the future vagrant user a sudo master.
+sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
+echo "vagrant        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
+chmod 0440 /etc/sudoers.d/vagrant
+
+sed -i -e "s/.*PermitRootLogin.*/PermitRootLogin yes/g" /etc/ssh/sshd_config
+sed -i -e "s/.*PasswordAuthentication.*/PasswordAuthentication yes/g" /etc/ssh/sshd_config
+
+%end

--- a/scripts/fedora/kernel.sh
+++ b/scripts/fedora/kernel.sh
@@ -37,7 +37,7 @@ error() {
 # Now that the system is running atop the updated kernel, we can install the
 # development files for the kernel. These files are required to compile the
 # virtualization kernel modules later in the provisioning process.
-retry dnf --assumeyes install kernel-tools kernel-devel kernel-headers
+retry dnf --assumeyes install kernel-tools kernel-devel kernel-devel-matched kernel-headers
 error
 
 # Now that the system is running on the updated kernel, we can remove the

--- a/templates/build.pkr.hcl
+++ b/templates/build.pkr.hcl
@@ -5,7 +5,8 @@ build {
     "source.parallels-iso.generic-fedora37-aarch64-parallels",
     "source.parallels-iso.generic-fedora38-aarch64-parallels",
     "source.parallels-iso.generic-fedora39-aarch64-parallels",
-    "source.parallels-iso.generic-fedora40-aarch64-parallels"
+    "source.parallels-iso.generic-fedora40-aarch64-parallels",
+    "source.parallels-iso.generic-fedora41b-aarch64-parallels"
   ]
 
   provisioner "shell" {

--- a/templates/fedora41b-aarch64-parallels.pkr.hcl
+++ b/templates/fedora41b-aarch64-parallels.pkr.hcl
@@ -1,0 +1,39 @@
+source "parallels-iso" "generic-fedora41b-aarch64-parallels" {
+  vm_name                = "generic-fedora41b-aarch64-parallels"
+  output_directory       = "output/generic-fedora41b-aarch64-parallels"
+  cpus                   = 2
+  memory                 = 2048
+  disk_size              = 32768
+  iso_checksum           = "file:https://dl.fedoraproject.org/pub/fedora/linux/releases/test/41_Beta/Server/aarch64/iso/Fedora-Server-iso-41_Beta-1.2-aarch64-CHECKSUM"
+  iso_url                = "https://download.fedoraproject.org/pub/fedora/linux/releases/test/41_Beta/Server/aarch64/iso/Fedora-Server-netinst-aarch64-41_Beta-1.2.iso"
+  boot_keygroup_interval = "1s"
+  boot_wait              = "10s"
+  boot_command = [
+    "<up>e<wait1><down><down><wait2><leftCtrlOn>e<leftCtrlOff> ",
+    "<wait>inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/generic.fedora41b.vagrant.ks ",
+    "<wait>inst.text ",
+    "<wait>biosdevname=0 ",
+    "<wait>net.ifnames=0 ",
+    "<wait><leftCtrlOn>x<leftCtrlOff>"
+  ]
+  guest_os_type              = "fedora-core"
+  parallels_tools_flavor     = "lin-arm"
+  hard_drive_interface       = "sata"
+  http_directory             = "http"
+  parallels_tools_guest_path = "/root/parallels-tools-linux.iso"
+  parallels_tools_mode       = "upload"
+  prlctl = [
+    ["set", "{{ .Name }}", "--adaptive-hypervisor", "on"],
+    ["set", "{{ .Name }}", "--3d-accelerate", "off"],
+    ["set", "{{ .Name }}", "--videosize", "16"],
+    ["set", "{{ .Name }}", "--pmu-virt", "on"],
+    ["set", "{{ .Name }}", "--faster-vm", "on"]
+  ]
+  prlctl_version_file = "/root/parallels-tools-version.txt"
+  shutdown_command    = "echo 'vagrant' | sudo -S shutdown -P now"
+  skip_compaction     = false
+  ssh_username        = "root"
+  ssh_password        = "vagrant"
+  ssh_port            = 22
+  ssh_timeout         = "3600s"
+}

--- a/tpl/generic-fedora41b.rb
+++ b/tpl/generic-fedora41b.rb
@@ -1,0 +1,42 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+
+  config.vm.box_check_update = true
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+  # config.vm.synced_folder "~/", "/media/psf/Home"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  config.vm.provider :parallels do |v, override|
+    v.memory = 2048
+    v.cpus = 2
+
+    # Set disk size
+    v.customize "post-import", ["set", :id, "--device-set", "hdd0", "--no-fs-resize", "--size", "50000"]
+
+    v.linked_clone = false
+    v.update_guest_tools = false
+    v.customize ["set", :id, "--on-window-close", "keep-running"]
+    v.customize ["set", :id, "--startup-view", "headless"]
+    v.customize ["set", :id, "--pmu-virt", "on"]
+    v.customize ["set", :id, "--faster-vm", "on"]
+    v.customize ["set", :id, "--resource-quota", "unlimited"]
+    v.customize ["set", :id, "--time-sync", "on"]
+    # v.customize ["set", :id, "--shared-clipboard", "off"]
+    # v.customize ["set", :id, "--sync-host-printers", "off"]
+  end
+
+  config.vm.provision "shell", inline: <<-SHELL
+    # Upgrading kernel might break parallels-tools kernel modules
+    # dnf upgrade -y
+
+    # Resize root fs (cloud-utils-growpart)
+    growpart /dev/sda 3
+    btrfs filesystem resize max /
+  SHELL
+
+end


### PR DESCRIPTION
- Add Fedora 41 BETA box with kernel `6.11.5` and Parallels Tools `20.1.55732`.
- Update Fedora 40 box (`0.0.9`) with kernel `6.11.4` and Parallels Tools `20.1.55732`.
- Update Fedora 39 box (`0.0.9`) with kernel `6.11.4` and Parallels Tools `20.1.55732`.
  
Commits:
- **gitignore: ignore image_cache directory**
- **image: add f41 beta image**
